### PR TITLE
fix spelling `go to`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ Mac OS X:
 * <kbd>cmd-k cmd-k</kbd> : mark:toggle
 * <kbd>cmd-k cmd-a</kbd> : mark:select-to-mark
 * <kbd>cmd-k cmd-g</kbd> : mark:clear-mark
-* <kbd>cmd-k space</kbd> : mark:goto-mark
+* <kbd>cmd-k space</kbd> : mark:go-to-mark
 
 Linux/Windows
 
 * <kbd>ctrl-k ctrl-k</kbd> : mark:toggle
 * <kbd>ctrl-k ctrl-a</kbd> : mark:select-to-mark
 * <kbd>ctrl-k ctrl-g</kbd> : mark:clear-mark
-* <kbd>ctrl-k space</kbd>  : mark:goto-mark
+* <kbd>ctrl-k space</kbd>  : mark:go-to-mark

--- a/keymaps/mark.cson
+++ b/keymaps/mark.cson
@@ -2,11 +2,11 @@
 '.platform-darwin atom-text-editor':
   'cmd-k cmd-k' : 'mark:toggle'
   'cmd-k cmd-g' : 'mark:clear-mark'
-  'cmd-k space' : 'mark:goto-mark'
+  'cmd-k space' : 'mark:go-to-mark'
   'cmd-k cmd-a' : 'mark:select-to-mark'
 
 '.platform-linux atom-text-editor, .platform-windows atom-text-editor':
   'ctrl-k ctrl-k' : 'mark:toggle'
   'ctrl-k ctrl-g' : 'mark:clear-mark'
-  'ctrl-k space'  : 'mark:goto-mark'
+  'ctrl-k space'  : 'mark:go-to-mark'
   'ctrl-k ctrl-a' : 'mark:select-to-mark'

--- a/package.json
+++ b/package.json
@@ -3,12 +3,12 @@
   "main": "./lib/index",
   "author": "Michael Kleehammer <michael@kleehammer.com>",
   "version": "1.3.3",
-  "description": "Provides a buffer mark supporting select-to-mark and goto-mark",
+  "description": "Provides a buffer mark supporting select-to-mark and go-to-mark",
   "activationCommands": {
     "atom-text-editor": [
       "mark:toggle",
       "mark:clear-mark",
-      "mark:goto-mark",
+      "mark:go-to-mark",
       "mark:select-to-mark",
       "mark:swap"
     ]


### PR DESCRIPTION
fix issue https://github.com/olmokramer/atom-mark/issues/2